### PR TITLE
get maintenance id fix

### DIFF
--- a/scripts/maintenance-mode
+++ b/scripts/maintenance-mode
@@ -54,7 +54,11 @@ def get_hostid(api, name):
 def get_maintid(api, name, type):
     name = '{0} {1}'.format(name, type)
     try:
-        return api.maintenance.get(name)[0][u'maintenanceid']
+        m =  api.maintenance.get(name)
+        if m[0][u'name'] == name:
+            return m[0][u'maintenanceid']
+        else:
+            return None
     except:
         return None
 
@@ -70,7 +74,6 @@ def set_maint(api, name, type, duration=3600):
         timeperiods=[{"timeperiod_type": 0}])
 
 def clear_maint(api, name, type):
-    name = '{0} {1}'.format(name, type)
     maint_id = get_maintid(api, name, type)
     try:
         return api.maintenance.delete(maint_id)


### PR DESCRIPTION
Hi.
I'm using the maintenance-mode as a standalone script.
One problem is that, when I try to delete a "maintenance name" that does NOT exists, It clears the last one, that is not the correct one.
To avoid that, I introduced the "if".
Maybe it's not the clearest way....

The other problem is that you are using 2 times:

```
name = '{0} {1}'.format(name, type)
```

that concatenate 2 times the "type" var.
