### PR TITLE
Fix get hostid by name and maint id by name

### DIFF
--- a/scripts/maintenance-mode
+++ b/scripts/maintenance-mode
@@ -49,12 +49,12 @@ def get_api(config):
     return zapi
 
 def get_hostid(api, name):
-    return api.host.get(name)[0][u'hostid']
+    return api.host.get(filter={"host":name})[0][u'hostid']
 
 def get_maintid(api, name, type):
     name = '{0} {1}'.format(name, type)
     try:
-        m =  api.maintenance.get(name)
+        m =  api.maintenance.get(filter={"name":name})
         if m[0][u'name'] == name:
             return m[0][u'maintenanceid']
         else:


### PR DESCRIPTION
Hi!
I like your idea to use items and triggers as basis of maintenance mode, so I tried the script.

It's good, but I was not able to add some host except my zabbix server, and cannot delete created maintenance at all. 
I debugged the script and found incorrect requests to api. (see https://www.zabbix.com/documentation/2.4/manual/api/reference/host/get  and https://www.zabbix.com/documentation/2.4/manual/api/reference/maintenance/get)
api.host.get(name)  and  api.maintenance.get(name)  return full array of hosts and  maintenance.

So, I tried to   fix it

Best regards
